### PR TITLE
Add aarch64 architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased / develop
 
+### v1.0.1 - 2020-06-02
+- Added `aarch64` architecture.
+
 ### v1.0.0 - 2019-10-09
 - Replace console output with a (rotating) log handler.
 - Move to `python:3-alpine` base image for greater compatibility with different platforms.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ location if you want to keep logfiles between containers or have easy access to 
 ## Supported architectures:
 - `linux/amd64`
 - `linux/arm64`
+- `linux/aarch64`
 - `linux/386`
 - `linux/arm/v7`
 - `linux/arm/v6`

--- a/build-push.sh
+++ b/build-push.sh
@@ -7,5 +7,5 @@ tagname=${tagname:-develop}
 # docker buildx use dsmrbuilder
 # docker buildx inspect --bootstrap
 
-docker buildx build --platform linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6 -t trizz/dsmr-remote-datalogger:${tagname} --push . && \
+docker buildx build --platform linux/amd64,linux/arm64,linux/aarch64,linux/386,linux/arm/v7,linux/arm/v6 -t trizz/dsmr-remote-datalogger:${tagname} --push . && \
 docker buildx imagetools inspect docker.io/trizz/dsmr-remote-datalogger:${tagname}


### PR DESCRIPTION
Add support for `aarch64` architecture, found in Raspberry Pi 3 B models.